### PR TITLE
update Github action - change name of lint workflow, add trigger to run on PRs

### DIFF
--- a/.github/workflows/lint-on-push.yml
+++ b/.github/workflows/lint-on-push.yml
@@ -1,13 +1,14 @@
-name: Lint on push
+name: Lint and check formatting
 
 on:
   push:
     branches:
       - new
+  pull_request:
 
 jobs:
   lint:
-    name: The lint job
+    name: Run pre-commit
     runs-on: ubuntu-latest
     steps:
 


### PR DESCRIPTION
update Github action workflow yml file:
- change name of lint workflow
- add trigger to run on PRs

(No changes to Django app code)

I will merge this PR since it is only a small change, and only to the GitHub actions file.  I want to get this in before opening another PR with larger set of changes so it runs checks on that new PR.